### PR TITLE
Add CLI operations guide for Step C workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This document complements `CHANGES.md` by recording release-oriented milestones after Step C5 validation.
+
+## [0.6.0] - 2025-09-27 - Step C Completion
+- Completed the Step C automation suites (smoke, spec, integration) and enabled continuous integration via GitHub Actions.
+- Finalised deliverables checklist coverage for Steps A–C and added release tooling scripts.
+- Captured the full MVP snapshot set for both C and C++ tracks through Step B and confirmed successful end-to-end testing.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,3 +86,13 @@
 ## SEQ0102–SEQ0104 – Step C CI workflow
 - Added the GitHub Actions pipeline that checks out the repo, configures CMake, builds all targets, and runs the entire `ctest` suite.
 - Documented the job sequence in `ci/README.md` so contributors understand the automated validation stages.
+
+## SEQ0105–SEQ0107 – Step C final validation
+- Published the Step C5 deliverables checklist summarising Pass status for planning docs, code foundations, and automation assets.
+- Added release collateral (`CHANGELOG.md`, `VERSIONING.md`) and documented the `scripts/new_version.sh` helper in the scripts index.
+- Implemented the `new_version.sh` tool to prepend dated entries to `CHANGELOG.md`, aligning with the repository versioning flow.
+
+## SEQ0108 – Step C CLI operations guide
+- Authored a comprehensive CLI reference covering build setup, test execution, runtime invocation, snapshotting, and release tooling workflows.
+- Captured troubleshooting advice for common terminal issues (ctest typos, port conflicts, stale build trees) to reduce friction for learners advancing through SEQ milestones.
+- Linked commands back to the supporting automation scripts so contributors can cross-reference behaviour with the implementation.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,16 @@
+# Versioning Strategy
+
+- **Format**: `MAJOR.MINOR.PATCH` where `MAJOR` tracks the highest completed MVP stage across
+  both implementations, `MINOR` increments for substantial cross-track features (e.g., new
+  automation suites), and `PATCH` covers maintenance fixes without new SEQ ranges.
+- **Current release**: `0.6.0`, representing parity through C MVP5 and C++ MVP6 plus Step C
+  automation.
+- **Snapshot linkage**: Each increment to `MINOR` or `MAJOR` must be accompanied by fresh
+  snapshots under `snapshots/<track>/mvpX` produced via `scripts/snapshot_mvp.sh`.
+- **Change tracking**: Detailed sequence-by-sequence notes remain in `CHANGES.md`; release
+  summaries belong in `CHANGELOG.md`.
+- **Bumping flow**:
+  1. Ensure `ctest` passes for all suites (`smoke`, `spec`, `integration`).
+  2. Capture updated snapshots for the affected track(s).
+  3. Run `scripts/new_version.sh <version> "Title" "Bullet..."` to prepend a release entry.
+  4. Update any relevant documentation with new SEQ identifiers in chronological order.

--- a/docs/CLI-Operations.md
+++ b/docs/CLI-Operations.md
@@ -1,0 +1,139 @@
+# CLI Operations Guide
+
+Sequence: SEQ0108  \
+Track: Shared  \
+MVP: Step C  \
+Change: Document end-to-end command-line workflows for builds, tests, runtime, and release.  \
+Tests: documentation_only
+
+## 1. Audience and Goals
+This guide targets learners following the MVP/SEQ curriculum who need a single reference for every terminal command that keeps the project moving—from configuring builds to cutting releases. Each workflow includes copy-paste ready examples and troubleshooting notes so contributors can practice confidently without guessing the syntax.
+
+## 2. Environment Preparation
+1. Ensure the toolchain is installed:
+   - GCC/Clang with C11 and C++17 support
+   - CMake 3.20+
+   - Python 3.10+
+   - `ninja` or `make` (optional but recommended)
+2. Clone the repository and start in the project root:
+   ~~~bash
+   git clone <repo-url>
+   cd log-crafter
+   ~~~
+3. Clean up old build artifacts when switching branches:
+   ~~~bash
+   rm -rf build
+   ~~~
+
+## 3. Configure and Build
+All build commands run from the repository root.
+
+| Step | Command | Notes |
+|------|---------|-------|
+| Configure | `cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo` | Creates (or refreshes) the `build/` tree with tests enabled.【F:CMakeLists.txt†L1-L40】 |
+| Build | `cmake --build build --parallel` | Builds every MVP target plus tests. Use `--target logcrafter_c_mvp5` to compile only the latest C binary if desired.【F:work/c/CMakeLists.txt†L1-L40】 |
+| Clean | `cmake --build build --target clean` | Removes compiled objects while keeping configuration files. |
+
+When switching toolchains or generators, rerun the configure step to update CMake cache files.
+
+## 4. Running the Servers Locally
+After building, binaries live in `build/work/<track>/`.
+
+### 4.1 C Track (MVP5)
+- Binary: `build/work/c/logcrafter_c_mvp5`
+- Typical launch:
+  ~~~bash
+  build/work/c/logcrafter_c_mvp5 -p 11000 -P -d ./logs/c -s 25
+  ~~~
+- Flags:
+  | Flag | Purpose | Default |
+  |------|---------|---------|
+  | `-p PORT` | Listener port (query port binds to `PORT-1`). | `9999` |
+  | `-P` | Enable persistence layer. | Disabled |
+  | `-d DIR` | Directory for persisted logs. | `./logs` |
+  | `-s SIZE_MB` | Rotation threshold in megabytes. | `10` |
+  | `-h` | Print usage banner and exit. | — |
+
+Stop the server with `Ctrl+C` (SIGINT) to ensure a graceful shutdown and persistence flush.
+
+### 4.2 C++ Track (MVP6)
+- Binary: `build/work/cpp/logcrafter_cpp_mvp6`
+- Typical launch (with IRC):
+  ~~~bash
+  build/work/cpp/logcrafter_cpp_mvp6 -p 12000 -P -d ./logs/cpp -I 6669 -i
+  ~~~
+- Additional flags beyond the C track:
+  | Flag | Purpose | Default |
+  |------|---------|---------|
+  | `-i` | Enable IRC bridge with default port 6667. | Disabled |
+  | `-I PORT` | Override IRC port when `-i` is supplied. | `6667` |
+
+### 4.3 Quick Smoke Interaction
+1. Start the desired server in one terminal.
+2. From another terminal, send a log entry:
+   ~~~bash
+   printf 'level=INFO msg="hello"\n' | nc localhost 11000
+   ~~~
+3. Query it back:
+   ~~~bash
+   printf 'QUERY level=INFO\n' | nc localhost 10999
+   ~~~
+
+## 5. Test Execution Matrix
+Every suite is available through `ctest`. Commands assume the project has already been built.
+
+| Purpose | Command | Coverage |
+|---------|---------|----------|
+| Smoke regression | `scripts/run_smoke.sh` | Fast readiness checks (bindings, shutdown, capacity, IRC boot).【F:scripts/run_smoke.sh†L1-L16】 |
+| Spec verification | `ctest --test-dir build -L spec --output-on-failure` | Protocol matrix (happy path, invalid input, partial I/O, timeouts, signal handling).【F:tests/spec/test_spec.py†L1-L160】 |
+| Integration flows | `scripts/run_integration.sh` | Multi-client broadcast, persistence replay, IRC bridge workflows.【F:scripts/run_integration.sh†L1-L16】【F:tests/integration/test_integration.py†L1-L200】 |
+| Full suite | `ctest --test-dir build --output-on-failure` | Runs smoke + spec + integration (same command CI uses). |
+| Targeted rerun | `ctest --test-dir build -R smoke_max_clients --output-on-failure` | Replace regex with the desired test name. |
+
+If a command fails immediately with “unknown option,” double-check spelling (`--output-on-failure`, not `--output-on-failur`).
+
+## 6. Snapshot and Release Tasks
+### 6.1 Creating MVP Snapshots
+Use the provided script after verifying tests for the track/MVP you want to freeze.
+~~~bash
+scripts/snapshot_mvp.sh c mvp5
+scripts/snapshot_mvp.sh cpp mvp6
+~~~
+The script copies `work/<track>` into `snapshots/<track>/<mvp>` and refuses to overwrite existing snapshots.【F:scripts/snapshot_mvp.sh†L1-L80】
+
+### 6.2 Publishing a New Version
+1. Update `VERSIONING.md` if policies change.
+2. Run the helper with the new version string and release summary:
+   ~~~bash
+   scripts/new_version.sh 1.3.0 "Add Step C CLI operations guide"
+   ~~~
+3. Review the updated `CHANGELOG.md` entry before committing.【F:scripts/new_version.sh†L1-L68】【F:CHANGELOG.md†L1-L8】
+
+## 7. Continuous Integration Reference
+CI reuses the same commands:
+1. `cmake -S . -B build`
+2. `cmake --build build --parallel`
+3. `ctest --test-dir build --output-on-failure`
+The workflow definition (`ci/github-actions.yml`) mirrors this order if you need to replicate the pipeline locally.【F:ci/github-actions.yml†L1-L23】
+
+## 8. Troubleshooting Checklist
+- **Build directory issues**: Delete `build/` and reconfigure if you see stale include paths or missing targets.
+- **Port conflicts**: Kill old server processes or change `-p`/`-I` values when smoke tests report bind errors.
+- **Persistence permissions**: Ensure the directory passed with `-d` is writable before enabling `-P`.
+- **Long-running tests**: Integration scenarios can take ~2–3 minutes; use the regex filter to iterate faster on failures.
+
+## 9. Quick Reference (Cheat Sheet)
+| Task | Command |
+|------|---------|
+| Configure project | `cmake -S . -B build`
+| Build everything | `cmake --build build --parallel`
+| Run smoke suite | `scripts/run_smoke.sh`
+| Run spec suite | `ctest --test-dir build -L spec --output-on-failure`
+| Run integration suite | `scripts/run_integration.sh`
+| Run all tests | `ctest --test-dir build --output-on-failure`
+| Launch C server | `build/work/c/logcrafter_c_mvp5 -p 11000 -P -d ./logs/c`
+| Launch C++ server with IRC | `build/work/cpp/logcrafter_cpp_mvp6 -p 12000 -i -I 6669`
+| Snapshot MVP | `scripts/snapshot_mvp.sh <track> <mvp>`
+| Prep release log | `scripts/new_version.sh <version> "summary"`
+
+Keep this guide handy while progressing through each SEQ—every critical CLI you need is now centralised in one document.

--- a/docs/DeliverablesChecklist.md
+++ b/docs/DeliverablesChecklist.md
@@ -1,0 +1,15 @@
+# Step C5 Deliverables Checklist
+
+## Step A – Specs & Diagrams
+- **Pass – Planning documentation**: Architecture overview, API, protocol, error, data model, performance, migration, and diagram references are published under `docs/`.【F:docs/RFC-0001-overview.md†L1-L40】【F:docs/API.md†L1-L40】【F:docs/Protocol.md†L1-L40】【F:docs/Errors.md†L1-L40】【F:docs/DataModel.md†L1-L40】【F:docs/Performance.md†L1-L40】【F:docs/Migration.md†L1-L40】【F:docs/Diagrams/component-shared.txt†L1-L40】
+- **Pass – Sequence mapping and assumptions**: Legacy-to-SEQ crosswalk and explicit assumptions captured for both tracks.【F:docs/SequenceMap.md†L1-L40】【F:docs/Assumptions.md†L1-L20】
+
+## Step B – Repository & Code Foundation
+- **Pass – Active work trees**: C and C++ implementations live under `work/` with SEQ-annotated sources and build targets wired through CMake.【F:work/c/src/main.c†L1-L40】【F:work/cpp/src/main.cpp†L1-L60】【F:CMakeLists.txt†L1-L40】
+- **Pass – Snapshots**: Frozen copies exist for every MVP stage across both tracks under `snapshots/`.【F:snapshots/c/mvp5/src/main.c†L1-L40】【F:snapshots/cpp/mvp6/src/main.cpp†L1-L60】
+- **Pass – Release collateral**: CHANGELOG, VERSIONING guidance, snapshot tooling, and the new-version helper script reside at the repository root and under `scripts/`.【F:CHANGELOG.md†L1-L8】【F:VERSIONING.md†L1-L16】【F:scripts/snapshot_mvp.sh†L1-L24】【F:scripts/new_version.sh†L1-L67】【F:scripts/README.md†L1-L28】
+
+## Step C – Tests & CI
+- **Pass – Automated suites**: Smoke, spec, and integration harnesses registered with CTest alongside helper scripts and load generator utilities.【F:tests/CMakeLists.txt†L1-L63】【F:tests/smoke/test_smoke.py†L1-L200】【F:tests/spec/test_spec.py†L1-L120】【F:tests/integration/test_integration.py†L1-L200】【F:scripts/run_smoke.sh†L1-L16】【F:scripts/run_integration.sh†L1-L16】【F:tools/load_generator.py†L1-L40】
+- **Pass – Continuous integration**: GitHub Actions workflow builds the project and executes the full `ctest` suite, with recent runs passing locally.【F:ci/github-actions.yml†L1-L23】【cd6edc†L1-L11】
+- **Pass – Developer CLI guidance**: A dedicated CLI operations guide documents every build, test, runtime, snapshot, and release command to support learners progressing through SEQ milestones.【F:docs/CLI-Operations.md†L1-L200】

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,13 @@ Change: Document Step C automation helpers.  \
 Tests: smoke_bind_conflict, smoke_dual_listener, smoke_shutdown_signal, smoke_max_clients,
 smoke_irc_boot, smoke_persistence_toggle
 
+Sequence: SEQ0105  \
+Track: Shared  \
+MVP: Step C  \
+Change: Document release tooling added during Step C5 validation.  \
+Tests: manual_usage_new_version
+
 - `run_smoke.sh` – Configure, build, and execute the smoke test label via `ctest -L smoke`.
 - `snapshot_mvp.sh` – Preserve the current `work/<track>` tree into `snapshots/<track>/<mvp>` (added earlier in Step B).
-
-Additional CI and integration scripts will land alongside future Step C sequences.
+- `new_version.sh` – Prepend a release entry to `CHANGELOG.md` once Step C validation completes and snapshots are refreshed.
+- `run_integration.sh` – Convenience wrapper around `ctest -L integration` for the long-running scenarios.

--- a/scripts/new_version.sh
+++ b/scripts/new_version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Sequence: SEQ0105
+# Track: Shared
+# MVP: Step C
+# Change: Automate release note creation by prepending entries to CHANGELOG.md
+#         using the MAJOR.MINOR.PATCH scheme outlined in VERSIONING.md.
+# Tests: manual_usage_new_version
+#
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <version> <title> [note ...]" >&2
+  exit 1
+fi
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "CHANGELOG.md not found in repository root." >&2
+  exit 1
+fi
+
+version="$1"
+shift
+release_title="$1"
+shift || true
+notes=("$@")
+
+changelog="CHANGELOG.md"
+entry_line=$(grep -n '^## \[' "$changelog" | head -n1 | cut -d: -f1 || true)
+if [[ -z "$entry_line" ]]; then
+  header_end=$(wc -l < "$changelog")
+  tail_start=0
+else
+  header_end=$((entry_line - 1))
+  tail_start=$entry_line
+fi
+
+tmp_file=$(mktemp)
+trap 'rm -f "$tmp_file"' EXIT
+
+if [[ "$header_end" -gt 0 ]]; then
+  head -n "$header_end" "$changelog" > "$tmp_file"
+else
+  : > "$tmp_file"
+fi
+
+date_utc=$(date -u +%Y-%m-%d)
+{
+  echo
+  echo "## [$version] - $date_utc - $release_title"
+  if [[ ${#notes[@]} -gt 0 ]]; then
+    for note in "${notes[@]}"; do
+      echo "- $note"
+    done
+  else
+    echo "- (no additional notes provided)"
+  fi
+  echo
+} >> "$tmp_file"
+
+if [[ $tail_start -gt 0 ]]; then
+  tail -n +"$tail_start" "$changelog" >> "$tmp_file"
+fi
+
+mv "$tmp_file" "$changelog"
+trap - EXIT
+
+echo "Added CHANGELOG entry for version $version"


### PR DESCRIPTION
## Summary
- add a CLI operations guide centralizing build, test, runtime, snapshot, and release commands for both tracks
- reference the new guide in the Step C5 deliverables checklist and document the work as SEQ0108 in CHANGES.md

## Testing
- cmake -S . -B build
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d762bd04208329baf659341a759c7a